### PR TITLE
fix: correct orb slug and add missing checkout step in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,14 @@ An example
 version: '2.1'
 
 orbs:
-  flox: flox/flox-orb@1.0.0
+  flox: flox/orb@1.0.0
 
 jobs:
   use-flox-orb:
     machine:
       image: ubuntu-2204:current
     steps:
+      - checkout
       - flox/install                    # <- Install Flox
       - flox/activate:                  # <- Run a command in a Flox environment
           environment: flox/nb


### PR DESCRIPTION
The getting started example in README.md references `flox/flox-orb@1.0.0` as the orb slug, but the correct published slug on the CircleCI registry is `flox/orb@1.0.0`. Using the wrong slug causes the job to fail immediately with an orb resolution error.

Also adds the missing `- checkout` step before `flox/install`, which is standard practice and required if the environment relies on anything in the repo.

Changes:
- Fix orb slug: `flox/flox-orb@1.0.0` → `flox/orb@1.0.0`
- Add `- checkout` step before `flox/install`