### PR TITLE
feat: bring orb to parity with GitHub Actions

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -51,9 +51,9 @@ jobs:
     steps:
       - checkout
       - flox/install:
-          disable-metrics: "true"
-          disable-upgrade-notifications: "true"
-          trusted-environments: "flox/nb"
+          disable_metrics: "true"
+          disable_upgrade_notifications: "true"
+          trusted_environments: "flox/nb"
       - flox/activate:
           dir: "."
           command: "circleci version"

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -45,6 +45,18 @@ jobs:
       - flox/activate:
           dir: "."
           command: "circleci version"
+  install-with-options-test:
+    machine:
+      image: ubuntu-2204:current
+    steps:
+      - checkout
+      - flox/install:
+          disable-metrics: "true"
+          disable-upgrade-notifications: "true"
+          trusted-environments: "flox/nb"
+      - flox/activate:
+          dir: "."
+          command: "circleci version"
 
 workflows:
   test-deploy:
@@ -54,6 +66,8 @@ workflows:
       - remote-environment-test:
           filters: *filters
       - local-environment-test:
+          filters: *filters
+      - install-with-options-test:
           filters: *filters
       # The orb must be re-packed for publishing, and saved to the workspace.
       - orb-tools/pack:
@@ -67,5 +81,6 @@ workflows:
             - orb-tools/pack
             - remote-environment-test
             - local-environment-test
+            - install-with-options-test
           #TODO: context: <publishing-context>
           filters: *release-filters

--- a/README.md
+++ b/README.md
@@ -60,6 +60,62 @@ jobs:
           command: python --version
 ```
 
+## 📖 Commands
+
+### `flox/install`
+
+Installs Flox on the runner. If Nix is already present, installs
+via `nix profile install`; otherwise downloads the platform package.
+
+| Parameter | Default | Description |
+| --------- | ------- | ----------- |
+| `version` | `""` | Specific version to install |
+| `channel` | `stable` | `stable`, `qa`, `nightly`, or a commit hash |
+| `disable_metrics` | `"false"` | Disable anonymous usage statistics |
+| `retries` | `"3"` | Retry count for download and install |
+| `trusted_environments` | `""` | Comma-separated FloxHub envs to trust |
+| `extra_nix_config` | `""` | Lines to append to `/etc/nix/nix.conf` |
+| `extra_substituters` | `""` | Space-separated Nix binary cache URLs |
+| `extra_substituter_keys` | `""` | Public keys for extra substituters |
+| `proxy` | `""` | HTTP/HTTPS/SOCKS5 proxy URL |
+| `disable_upgrade_notifications` | `"true"` | Suppress upgrade notifications |
+| `extra_flox_config` | `""` | Key=value pairs for `flox config --set` |
+
+### `flox/activate`
+
+Runs a command inside a Flox environment.
+
+| Parameter | Default | Description |
+| --------- | ------- | ----------- |
+| `command` | `""` | Command to run (required) |
+| `environment` | `""` | Remote environment (e.g. `flox/nb`) |
+| `dir` | `""` | Path containing a `.flox/` directory |
+
+### Examples
+
+```yml
+# Minimal: install and activate a remote environment
+- flox/install
+- flox/activate:
+    environment: flox/nb
+    command: python --version
+
+# With options
+- flox/install:
+    disable_metrics: "true"
+    trusted_environments: "myorg/myenv"
+- flox/activate:
+    dir: "."
+    command: my-tool --version
+
+# Using a proxy
+- flox/install:
+    proxy: "http://proxy.example.com:8080"
+- flox/activate:
+    environment: flox/nb
+    command: python --version
+```
+
 ## 📫 Have a question? Want to chat? Ran into a problem?
 
 We are happy to welcome you to our [Discourse forum][discourse] and answer your

--- a/README.md
+++ b/README.md
@@ -46,13 +46,14 @@ An example
 version: '2.1'
 
 orbs:
-  flox: flox/flox-orb@1.0.0
+  flox: flox/orb@1.0.0
 
 jobs:
   use-flox-orb:
     machine:
       image: ubuntu-2204:current
     steps:
+      - checkout
       - flox/install                    # <- Install Flox
       - flox/activate:                  # <- Run a command in a Flox environment
           environment: flox/nb

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -14,7 +14,7 @@ parameters:
       Release environment (or release channel) from which
       to install Flox from. One of the following: stable,
       qa, nightly or specify a commit.
-  disable-metrics:
+  disable_metrics:
     type: string
     default: "false"
     description: >
@@ -25,24 +25,24 @@ parameters:
     description: >
       Number of retries for downloading and installing
       Flox.
-  trusted-environments:
+  trusted_environments:
     type: string
     default: ""
     description: >
       Comma-separated list of FloxHub environments to
       trust automatically (e.g. owner/env1,owner/env2).
-  extra-nix-config:
+  extra_nix_config:
     type: string
     default: ""
     description: >
       Additional lines to append to /etc/nix/nix.conf.
-  extra-substituters:
+  extra_substituters:
     type: string
     default: ""
     description: >
       Space-separated Nix binary cache URLs to add as
       trusted substituters.
-  extra-substituter-keys:
+  extra_substituter_keys:
     type: string
     default: ""
     description: >
@@ -53,12 +53,12 @@ parameters:
     default: ""
     description: >
       HTTP/HTTPS/SOCKS5 proxy URL for network requests.
-  disable-upgrade-notifications:
+  disable_upgrade_notifications:
     type: string
     default: "true"
     description: >
       Suppress flox upgrade notifications in CI output.
-  extra-flox-config:
+  extra_flox_config:
     type: string
     default: ""
     description: >
@@ -72,12 +72,12 @@ steps:
       environment:
         PARAM_VERSION: <<parameters.version>>
         PARAM_CHANNEL: <<parameters.channel>>
-        PARAM_DISABLE_METRICS: <<parameters.disable-metrics>>
+        PARAM_DISABLE_METRICS: <<parameters.disable_metrics>>
         PARAM_RETRIES: <<parameters.retries>>
-        PARAM_TRUSTED_ENVS: <<parameters.trusted-environments>>
-        PARAM_EXTRA_NIX_CONFIG: <<parameters.extra-nix-config>>
-        PARAM_EXTRA_SUBSTITUTERS: <<parameters.extra-substituters>>
-        PARAM_EXTRA_SUBSTITUTER_KEYS: <<parameters.extra-substituter-keys>>
+        PARAM_TRUSTED_ENVS: <<parameters.trusted_environments>>
+        PARAM_EXTRA_NIX_CONFIG: <<parameters.extra_nix_config>>
+        PARAM_EXTRA_SUBSTITUTERS: <<parameters.extra_substituters>>
+        PARAM_EXTRA_SUBSTITUTER_KEYS: <<parameters.extra_substituter_keys>>
         PARAM_PROXY: <<parameters.proxy>>
-        PARAM_DISABLE_UPGRADE: <<parameters.disable-upgrade-notifications>>
-        PARAM_EXTRA_FLOX_CONFIG: <<parameters.extra-flox-config>>
+        PARAM_DISABLE_UPGRADE: <<parameters.disable_upgrade_notifications>>
+        PARAM_EXTRA_FLOX_CONFIG: <<parameters.extra_flox_config>>

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -11,8 +11,59 @@ parameters:
     type: string
     default: stable
     description: >
-      Release environment (or release channel) from which to install Flox from.
-      One of the following: stable, qa, nightly or specify a commit.
+      Release environment (or release channel) from which
+      to install Flox from. One of the following: stable,
+      qa, nightly or specify a commit.
+  disable-metrics:
+    type: string
+    default: "false"
+    description: >
+      Disable sending anonymous usage statistics to flox.
+  retries:
+    type: string
+    default: "3"
+    description: >
+      Number of retries for downloading and installing
+      Flox.
+  trusted-environments:
+    type: string
+    default: ""
+    description: >
+      Comma-separated list of FloxHub environments to
+      trust automatically (e.g. owner/env1,owner/env2).
+  extra-nix-config:
+    type: string
+    default: ""
+    description: >
+      Additional lines to append to /etc/nix/nix.conf.
+  extra-substituters:
+    type: string
+    default: ""
+    description: >
+      Space-separated Nix binary cache URLs to add as
+      trusted substituters.
+  extra-substituter-keys:
+    type: string
+    default: ""
+    description: >
+      Space-separated public keys for the extra
+      substituters.
+  proxy:
+    type: string
+    default: ""
+    description: >
+      HTTP/HTTPS/SOCKS5 proxy URL for network requests.
+  disable-upgrade-notifications:
+    type: string
+    default: "true"
+    description: >
+      Suppress flox upgrade notifications in CI output.
+  extra-flox-config:
+    type: string
+    default: ""
+    description: >
+      Additional flox config key=value pairs, one per
+      line. Applied via flox config --set for each pair.
 
 steps:
   - run:
@@ -21,3 +72,12 @@ steps:
       environment:
         PARAM_VERSION: <<parameters.version>>
         PARAM_CHANNEL: <<parameters.channel>>
+        PARAM_DISABLE_METRICS: <<parameters.disable-metrics>>
+        PARAM_RETRIES: <<parameters.retries>>
+        PARAM_TRUSTED_ENVS: <<parameters.trusted-environments>>
+        PARAM_EXTRA_NIX_CONFIG: <<parameters.extra-nix-config>>
+        PARAM_EXTRA_SUBSTITUTERS: <<parameters.extra-substituters>>
+        PARAM_EXTRA_SUBSTITUTER_KEYS: <<parameters.extra-substituter-keys>>
+        PARAM_PROXY: <<parameters.proxy>>
+        PARAM_DISABLE_UPGRADE: <<parameters.disable-upgrade-notifications>>
+        PARAM_EXTRA_FLOX_CONFIG: <<parameters.extra-flox-config>>

--- a/src/examples/example.yml
+++ b/src/examples/example.yml
@@ -11,7 +11,7 @@ usage:
         image: ubuntu-2204:current
       steps:
         - flox/install:
-            disable-metrics: "true"
+            disable_metrics: "true"
         - flox/activate:
             environment: "flox/nb"
             command: "python --version"

--- a/src/examples/example.yml
+++ b/src/examples/example.yml
@@ -1,5 +1,5 @@
 description: >
-  Install Flox and command in a Flox environment.
+  Install Flox and run a command in a Flox environment.
 
 usage:
   version: 2.1
@@ -10,8 +10,8 @@ usage:
       machine:
         image: ubuntu-2204:current
       steps:
-        - flox/install
+        - flox/install:
+            disable-metrics: "true"
         - flox/activate:
             environment: "flox/nb"
             command: "python --version"
-

--- a/src/scripts/activate.sh
+++ b/src/scripts/activate.sh
@@ -1,23 +1,24 @@
 #!/bin/bash
+set -euo pipefail
 
 COMMAND="${PARAM_COMMAND}"
 ENVIRONMENT="${PARAM_ENV}"
 DIR="${PARAM_DIR}"
 
-if [ "$COMMAND" == "" ]; then
+if [ -z "$COMMAND" ]; then
   echo "command parameter is required."
   exit 2
 fi
 
 ACTIVATE="flox activate"
-if [ "$ENVIRONMENT" != "" ]; then
-  ACTIVATE="$ACTIVATE --reference=$ENVIRONMENT"
+if [ -n "$ENVIRONMENT" ]; then
+  ACTIVATE="$ACTIVATE -r=$ENVIRONMENT"
 fi
-if [ "$DIR" != "" ]; then
+if [ -n "$DIR" ]; then
   ACTIVATE="$ACTIVATE --dir=$DIR"
 fi
 
-ACTIVATE="$ACTIVATE -- $COMMAND"
+ACTIVATE="$ACTIVATE -c \"$COMMAND\""
 
 echo "Running: $ACTIVATE"
 

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -1,85 +1,259 @@
 #!/bin/bash
+set -euo pipefail
 
 VERSION="${PARAM_VERSION}"
 CHANNEL="${PARAM_CHANNEL:-stable}"
+DISABLE_METRICS="${PARAM_DISABLE_METRICS:-false}"
+RETRIES="${PARAM_RETRIES:-3}"
+PROXY="${PARAM_PROXY:-}"
+TRUSTED_ENVS="${PARAM_TRUSTED_ENVS:-}"
+EXTRA_NIX_CONFIG="${PARAM_EXTRA_NIX_CONFIG:-}"
+EXTRA_SUBSTITUTERS="${PARAM_EXTRA_SUBSTITUTERS:-}"
+EXTRA_SUBSTITUTER_KEYS="${PARAM_EXTRA_SUBSTITUTER_KEYS:-}"
+DISABLE_UPGRADE="${PARAM_DISABLE_UPGRADE:-true}"
+EXTRA_FLOX_CONFIG="${PARAM_EXTRA_FLOX_CONFIG:-}"
 
-OS_FAMILY=$(uname -s | tr '[:upper:]' '[:lower:]')
-OS_ARCH=$(uname -m | tr '[:upper:]' '[:lower:]')
+FLOX_SUBSTITUTER="https://cache.flox.dev"
+FLOX_PUBLIC_KEY="flox-cache-public-1:7F4OyH7ZCnFhcze3fJdfyXYLQw/aV7GEed86nQ7IsOs="
 
+# ── Set metrics ─────────────────────────────────────────
+export FLOX_DISABLE_METRICS="$DISABLE_METRICS"
 
-DOWNLOAD_URL="https://downloads.flox.dev"
-case $CHANNEL in
-  stable|qa|nightly) DOWNLOAD_URL="$DOWNLOAD_URL/by-env/$CHANNEL" ;;
-  *) DOWNLOAD_URL="$DOWNLOAD_URL/by-commit/$CHANNEL" ;;
-esac
-
-if [ "$VERSION" != "" ]; then
-  VERSION="-$VERSION"
-fi
-
-case $OS_FAMILY in
-  darwin)
-    case $OS_ARCH in
-      arm64)  DOWNLOAD_URL="$DOWNLOAD_URL/osx/flox$VERSION.aarch64-darwin.pkg" ;;
-      x86_64) DOWNLOAD_URL="$DOWNLOAD_URL/osx/flox$VERSION.x86_64-darwin.pkg" ;;
-      *)
-        echo "Unsupported OS architecture: $OS_ARCH"
-        exit 3
-        ;;
-    esac
-    ;;
-  linux)
-    if command -v dpkg >/dev/null; then
-      INSTALLER_TYPE="deb"
-    elif command -v rpm >/dev/null; then
-      INSTALLER_TYPE="rpm"
-    else
-      echo "Neither dpkg nor rpm package manager is available."
-      exit 4
-    fi
-    case $OS_ARCH in
-      arm64)  DOWNLOAD_URL="$DOWNLOAD_URL/$INSTALLER_TYPE/flox$VERSION.aarch64-linux.$INSTALLER_TYPE" ;;
-      x86_64) DOWNLOAD_URL="$DOWNLOAD_URL/$INSTALLER_TYPE/flox$VERSION.x86_64-linux.$INSTALLER_TYPE" ;;
-      *)
-        echo "Unsupported OS architecture: $OS_ARCH"
-        exit 3
-        ;;
-    esac
-    ;;
-  *)
-    echo "Unsupported OS family: $OS_FAMILY"
-    exit 2
-    ;;
-esac
-
-
-echo "Downloading flox from $DOWNLOAD_URL url ..."
-
-DOWNLOADED_FILE=$(basename "$DOWNLOAD_URL")
-curl --user-agent "install-flox-action" \
-    "$DOWNLOAD_URL" \
-    --output "$DOWNLOADED_FILE";
-
-
-echo "Installing flox..."
-
+# ── Sudo helper ─────────────────────────────────────────
 SUDO=''
 if [ "$EUID" -ne 0 ]; then
   SUDO='sudo'
 fi
 
-case $DOWNLOADED_FILE in
-  *.rpm)
-    $SUDO rpm -i "$DOWNLOADED_FILE";
-    ;;
-  *.deb)
-    $SUDO dpkg -i "$DOWNLOADED_FILE";
-    ;;
-  *.pkg)
-    $SUDO installer -pkg "$DOWNLOADED_FILE" -target /;
-    ;;
-  *)
-    echo >&2 "Aborting: Unknown file '$DOWNLOADED_FILE' downloaded. Not sure how to install it.";
-    exit 1;
-    ;;
-esac
+# ── Proxy setup ─────────────────────────────────────────
+PROXY_ARGS=""
+if [ -n "$PROXY" ]; then
+  PROXY_ARGS="--proxy $PROXY"
+  export HTTPS_PROXY="$PROXY"
+  export HTTP_PROXY="$PROXY"
+  export ALL_PROXY="$PROXY"
+  echo "Using proxy: $PROXY"
+fi
+
+# ── Configure Nix substituter ──────────────────────────
+configure_nix_substituter() {
+  local nix_conf="/etc/nix/nix.conf"
+  $SUDO mkdir -p /etc/nix
+
+  if [ -f "$nix_conf" ] && grep -q "$FLOX_SUBSTITUTER" "$nix_conf"; then
+    echo "Flox substituter already configured"
+    return
+  fi
+
+  $SUDO bash -c "cat >> $nix_conf" <<NIXCONF
+
+# Added by flox-orb
+extra-trusted-substituters = $FLOX_SUBSTITUTER
+extra-trusted-public-keys = $FLOX_PUBLIC_KEY
+NIXCONF
+  echo "Configured Flox substituter in $nix_conf"
+}
+
+# ── Install via existing Nix ───────────────────────────
+install_via_nix() {
+  echo "Nix detected - installing Flox via nix profile install"
+  configure_nix_substituter
+
+  nix profile install \
+    --experimental-features "nix-command flakes" \
+    --extra-substituters "$FLOX_SUBSTITUTER" \
+    --extra-trusted-public-keys "$FLOX_PUBLIC_KEY" \
+    --accept-flake-config \
+    "github:flox/flox/latest"
+
+  flox --version
+  echo "Flox installed successfully via existing Nix"
+}
+
+# ── Install via package download ───────────────────────
+install_via_package() {
+  local os_family
+  local os_arch
+  os_family=$(uname -s | tr '[:upper:]' '[:lower:]')
+  os_arch=$(uname -m | tr '[:upper:]' '[:lower:]')
+
+  local download_url="https://downloads.flox.dev"
+  case $CHANNEL in
+    stable|qa|nightly)
+      download_url="$download_url/by-env/$CHANNEL"
+      ;;
+    *)
+      download_url="$download_url/by-commit/$CHANNEL"
+      ;;
+  esac
+
+  local version_suffix=""
+  if [ -n "$VERSION" ]; then
+    version_suffix="-$VERSION"
+  fi
+
+  case $os_family in
+    darwin)
+      case $os_arch in
+        arm64)
+          download_url="$download_url/osx/flox${version_suffix}.aarch64-darwin.pkg"
+          ;;
+        x86_64)
+          download_url="$download_url/osx/flox${version_suffix}.x86_64-darwin.pkg"
+          ;;
+        *)
+          echo "Unsupported architecture: $os_arch"
+          exit 3
+          ;;
+      esac
+      ;;
+    linux)
+      local installer_type
+      if command -v dpkg >/dev/null; then
+        installer_type="deb"
+      elif command -v rpm >/dev/null; then
+        installer_type="rpm"
+      else
+        echo "Neither dpkg nor rpm found."
+        exit 4
+      fi
+      case $os_arch in
+        aarch64|arm64)
+          download_url="$download_url/$installer_type/flox${version_suffix}.aarch64-linux.$installer_type"
+          ;;
+        x86_64)
+          download_url="$download_url/$installer_type/flox${version_suffix}.x86_64-linux.$installer_type"
+          ;;
+        *)
+          echo "Unsupported architecture: $os_arch"
+          exit 3
+          ;;
+      esac
+      ;;
+    *)
+      echo "Unsupported OS: $os_family"
+      exit 2
+      ;;
+  esac
+
+  echo "Downloading flox from $download_url ..."
+
+  local downloaded_file
+  downloaded_file=$(mktemp -d -t "tmp.flox-orb-XXXXXXXX")/$(basename "$download_url")
+  # shellcheck disable=SC2086
+  curl --user-agent "flox-orb" \
+      $PROXY_ARGS \
+      --retry "$RETRIES" \
+      --retry-delay 5 \
+      --retry-all-errors \
+      "$download_url" \
+      --output "$downloaded_file"
+
+  echo "Installing flox..."
+
+  local retry_delay=5
+  for attempt in $(seq 1 "$RETRIES"); do
+    echo "Installation attempt $attempt of $RETRIES..."
+    if install_package "$downloaded_file"; then
+      echo "Installation succeeded on attempt $attempt"
+      break
+    else
+      if [ "$attempt" -eq "$RETRIES" ]; then
+        echo >&2 "Installation failed after $RETRIES attempts"
+        exit 1
+      fi
+      echo "Retrying in ${retry_delay}s..."
+      sleep "$retry_delay"
+    fi
+  done
+
+  rm -f "$downloaded_file"
+
+  flox --version
+  echo "Flox installed successfully via package"
+}
+
+install_package() {
+  local file="$1"
+  case $file in
+    *.rpm)
+      $SUDO rpm -i --notriggers "$file"
+      ;;
+    *.deb)
+      $SUDO dpkg -i --no-triggers "$file"
+      ;;
+    *.pkg)
+      $SUDO installer -pkg "$file" -target /
+      ;;
+    *)
+      echo >&2 "Unknown file type: $file"
+      exit 1
+      ;;
+  esac
+}
+
+# ── Post-install configuration ─────────────────────────
+configure_post_install() {
+  local nix_conf="/etc/nix/nix.conf"
+
+  # Extra nix config
+  if [ -n "$EXTRA_NIX_CONFIG" ]; then
+    $SUDO mkdir -p /etc/nix
+    echo "$EXTRA_NIX_CONFIG" | $SUDO tee -a "$nix_conf" >/dev/null
+    echo "Applied extra nix config"
+  fi
+
+  # Extra substituters
+  if [ -n "$EXTRA_SUBSTITUTERS" ]; then
+    $SUDO mkdir -p /etc/nix
+    {
+      echo "extra-trusted-substituters = $EXTRA_SUBSTITUTERS"
+      if [ -n "$EXTRA_SUBSTITUTER_KEYS" ]; then
+        echo "extra-trusted-public-keys = $EXTRA_SUBSTITUTER_KEYS"
+      fi
+    } | $SUDO tee -a "$nix_conf" >/dev/null
+    echo "Added extra substituters"
+  fi
+
+  # Trusted environments
+  if [ -n "$TRUSTED_ENVS" ]; then
+    IFS=',' read -ra envs <<< "$TRUSTED_ENVS"
+    for env in "${envs[@]}"; do
+      env=$(echo "$env" | xargs)
+      if [ -n "$env" ]; then
+        flox config --set "trusted_environments.\"$env\"" trust
+        echo "Trusted environment: $env"
+      fi
+    done
+  fi
+
+  # Disable upgrade notifications
+  if [ "$DISABLE_UPGRADE" = "true" ]; then
+    flox config --set upgrade_notifications false
+    echo "Upgrade notifications disabled"
+  fi
+
+  # Extra flox config
+  if [ -n "$EXTRA_FLOX_CONFIG" ]; then
+    while IFS= read -r line; do
+      line=$(echo "$line" | xargs)
+      if [ -n "$line" ] && [[ "$line" == *"="* ]]; then
+        local key="${line%%=*}"
+        local value="${line#*=}"
+        key=$(echo "$key" | xargs)
+        value=$(echo "$value" | xargs)
+        flox config --set "$key" "$value"
+        echo "Flox config: $key = $value"
+      fi
+    done <<< "$EXTRA_FLOX_CONFIG"
+  fi
+}
+
+# ── Main ───────────────────────────────────────────────
+if command -v nix >/dev/null 2>&1; then
+  install_via_nix
+else
+  install_via_package
+fi
+
+configure_post_install


### PR DESCRIPTION
## Summary

- Rewrite install script: add Nix install path, retry logic, proxy support, and post-install configuration
- Add 9 new install parameters: disable-metrics, retries, trusted-environments, extra-nix-config, extra-substituters, extra-substituter-keys, proxy, disable-upgrade-notifications, extra-flox-config
- Align activate script with activate-action: use `-r=` and `-c` flags
- Add install-with-options-test CI job

## Test plan

- [x] remote-environment-test passes
- [x] local-environment-test passes
- [x] install-with-options-test passes
- [x] shellcheck passes on both scripts